### PR TITLE
Modernise UI/UX with a zero-build vanilla rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,44 @@
 
 [JSON Tools Website](http://json.thomaschaplin.me)
 
-A simple website to manage JSON files
+A fast, free, browser-based tool to work with JSON files.
 
-Accepts [JSON](https://www.json.org/) or [JSON5](https://json5.org/) format
+Accepts [JSON](https://www.json.org/) or [JSON5](https://json5.org/) format.
 
-* Drag 'N' Drop Files
-* Pretty Print
-* Minify
-* Validate JSON
-* Validate JSON5
-* Download
-* Copy
-* Clear
+## Features
 
-### Todo:
-* Make readme pretty
-* Dark & Light Theme
-* Allow user to input file name on download
-* Upgrade textarea to use a code editor
-* JSON to CSV
-* Search
-* Scrape URL
-* Syntax Highlighting
-* Compare two JSON inputs
-* Example JSON
+- Pretty print
+- Minify
+- Validate
+- Copy to clipboard
+- Download (choose your own file name)
+- Clear
+- Drag 'n' drop files
+- Light & dark theme (remembers your choice, follows your system by default)
+
+Everything runs entirely in your browser &mdash; your data never leaves your machine.
+
+## Tech
+
+A zero-build static site: plain HTML, CSS and vanilla JavaScript (ES modules).
+The only dependency is [JSON5](https://json5.org/), loaded on demand from a CDN.
+No jQuery, no Bootstrap, no build step.
+
+## Development
+
+Because the site uses ES modules, open it through a local server rather than the
+`file://` protocol:
+
+```sh
+python3 -m http.server 8000
+# then visit http://localhost:8000
+```
+
+## Ideas / Todo
+
+- JSON to CSV
+- Search within input
+- Scrape URL
+- Syntax highlighting / code editor
+- Compare two JSON inputs
+- Load example JSON

--- a/index.html
+++ b/index.html
@@ -5,37 +5,67 @@
     <meta charset="UTF-8">
     <meta name="author" content="Thomas Chaplin">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="A fast, free tool to format, minify, validate, copy and download JSON and JSON5.">
+    <meta name="color-scheme" content="light dark">
     <title>JSON Tools</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO"
-        crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" href="style.css">
+    <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.ico" type="image/gif" sizes="16x16">
 </head>
 
-<body class="p-3 mb-2 bg-dark text-white" id="body" onload="blankText()">
-    <div>
-        <h1>JSON Tools</h1>
-        <textarea class="form-control" id="jsonField" onkeyup="blankText()" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Input or drop JSON or JSON5 here..."></textarea>
-        <br>
-        <button type="button" class="btn btn-light" id="pretty-button" onclick="prettyPrintJson()" disabled>Pretty Print JSON</button>
-        <button type="button" class="btn btn-light" id="pretty-button" onclick="prettyPrintJson5()" disabled>Pretty Print JSON5</button>
-        <button type="button" class="btn btn-light" id="minify-button" onclick="minifyJson()" disabled>Minify JSON</button>
-        <button type="button" class="btn btn-light" id="minify-button" onclick="minifyJson5()" disabled>Minify JSON5</button>
-        <button type="button" class="btn btn-light" id="validate-json-button" onclick="validateJson()" disabled>Validate JSON</button>
-        <button type="button" class="btn btn-light" id="validate-json5-button" onclick="validateJson5()" disabled>Validate JSON5</button>
-        <button type="button" class="btn btn-light" id="download-button" onclick="downloadJson()" disabled>Download</button>
-        <button type="button" class="btn btn-light" id="copy-button" onclick="copyText()" disabled>Copy</button>
-        <button type="button" class="btn btn-light" id="clear-button" onclick="clearText()" disabled>Clear</button> 
-        <br>
-        <a href='https://ko-fi.com/A0A4MCB0' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://az743702.vo.msecnd.net/cdn/kofi5.png?v=0' alt='Buy Me a Coffee at ko-fi.com' /></a>
-    </div>
-</body>
+<body>
+    <a class="skip-link" href="#jsonField">Skip to editor</a>
 
-<script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
-    crossorigin="anonymous"></script>
-<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
-    crossorigin="anonymous"></script>
-<script src="main.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/json5/0.5.1/json5.js"></script>
+    <div class="app">
+        <header class="app-header">
+            <h1 class="app-title">JSON Tools</h1>
+            <button type="button" id="themeToggle" class="icon-button" aria-label="Toggle colour theme" title="Toggle theme">
+                <span class="theme-icon" aria-hidden="true"></span>
+            </button>
+        </header>
+
+        <p class="app-subtitle">Format, minify and validate <strong>JSON</strong> or <strong>JSON5</strong> &mdash; right in your browser.</p>
+
+        <div class="toolbar">
+            <fieldset class="mode-toggle" aria-label="Format mode">
+                <legend class="visually-hidden">Format mode</legend>
+                <label class="mode-option">
+                    <input type="radio" name="mode" value="json" checked>
+                    <span>JSON</span>
+                </label>
+                <label class="mode-option">
+                    <input type="radio" name="mode" value="json5">
+                    <span>JSON5</span>
+                </label>
+            </fieldset>
+
+            <div class="actions">
+                <button type="button" class="button" data-action="pretty" disabled>Pretty Print</button>
+                <button type="button" class="button" data-action="minify" disabled>Minify</button>
+                <button type="button" class="button" data-action="validate" disabled>Validate</button>
+                <button type="button" class="button" data-action="copy" disabled>Copy</button>
+                <button type="button" class="button" data-action="download" disabled>Download</button>
+                <button type="button" class="button button-ghost" data-action="clear" disabled>Clear</button>
+            </div>
+        </div>
+
+        <div class="editor" id="dropZone">
+            <textarea class="editor-input" id="jsonField" autocomplete="off" autocorrect="off"
+                autocapitalize="off" spellcheck="false"
+                placeholder="Paste, type, or drop a JSON / JSON5 file here&hellip;"></textarea>
+            <div class="drop-overlay" aria-hidden="true">Drop file to load</div>
+        </div>
+
+        <footer class="app-footer">
+            <a href="https://ko-fi.com/A0A4MCB0" target="_blank" rel="noopener">
+                <img height="36" style="border:0;height:36px;" src="https://az743702.vo.msecnd.net/cdn/kofi5.png?v=0"
+                    alt="Buy Me a Coffee at ko-fi.com" loading="lazy" />
+            </a>
+        </footer>
+    </div>
+
+    <div id="toasts" class="toasts" role="status" aria-live="polite" aria-atomic="false"></div>
+
+    <script type="module" src="main.js"></script>
+</body>
 
 </html>

--- a/main.js
+++ b/main.js
@@ -1,155 +1,239 @@
+const INDENT = 2;
+const THEME_KEY = "json-tools-theme";
+const JSON5_URL = "https://cdn.jsdelivr.net/npm/json5@2/+esm";
+
+// JSON5 is loaded lazily from a CDN the first time it is needed, so the app
+// (and all JSON-only features) work instantly with no network dependency.
+let json5Promise;
+function loadJSON5() {
+    if (!json5Promise) {
+        json5Promise = import(/* @vite-ignore */ JSON5_URL).then((m) => m.default || m);
+    }
+    return json5Promise;
+}
+
+// Each format mode exposes a matching parse/stringify pair. JSON is synchronous;
+// JSON5 resolves its library on demand.
+const parsers = {
+    json: {
+        label: "JSON",
+        load: () => Promise.resolve({
+            parse: (text) => JSON.parse(text),
+            stringify: (value, indent) => JSON.stringify(value, undefined, indent),
+        }),
+    },
+    json5: {
+        label: "JSON5",
+        load: () => loadJSON5().then((JSON5) => ({
+            parse: (text) => JSON5.parse(text),
+            stringify: (value, indent) => JSON5.stringify(value, undefined, indent),
+        })),
+    },
+};
+
+const field = document.getElementById("jsonField");
+const dropZone = document.getElementById("dropZone");
+const toasts = document.getElementById("toasts");
+const themeToggle = document.getElementById("themeToggle");
+const actionButtons = Array.from(document.querySelectorAll(".button"));
+
+/* ------------------------------------------------------------------ helpers */
+
+function currentMode() {
+    const checked = document.querySelector('input[name="mode"]:checked');
+    return parsers[checked && parsers[checked.value] ? checked.value : "json"];
+}
+
 function rawJsonData() {
-    return document.getElementById(`jsonField`).value
+    return field.value;
 }
 
-function validateJson() {
+function toast(message, { type = "info", title } = {}) {
+    const el = document.createElement("div");
+    el.className = `toast toast--${type}`;
+    if (title) {
+        const heading = document.createElement("p");
+        heading.className = "toast__title";
+        heading.textContent = title;
+        el.appendChild(heading);
+    }
+    const body = document.createElement("p");
+    body.className = "toast__body";
+    body.textContent = message;
+    el.appendChild(body);
+    toasts.appendChild(el);
+
+    const remove = () => {
+        el.classList.add("is-leaving");
+        el.addEventListener("animationend", () => el.remove(), { once: true });
+    };
+    setTimeout(remove, type === "error" ? 6000 : 3000);
+}
+
+// Parse with the active mode, surfacing errors as toasts. Returns a result
+// object so callers can distinguish a parse failure from a parsed value.
+// Async because the JSON5 codec may need to be fetched on first use.
+async function parse() {
+    const mode = currentMode();
+    let codec;
     try {
-        JSON.parse(rawJsonData())
-        alert(`Valid JSON`)
-        return true
+        codec = await mode.load();
     } catch (error) {
-        alert(error)
-        return false
+        toast("Could not load the JSON5 library. Check your connection and try again.", {
+            type: "error",
+            title: "Library unavailable",
+        });
+        return { ok: false };
     }
-}
-
-function validateJson5() {
     try {
-        JSON5.parse(rawJsonData())
-        alert(`Valid JSON5`)
-        return true
+        return { ok: true, value: codec.parse(rawJsonData()), codec };
     } catch (error) {
-        alert(error)
-        return false
+        toast(error.message, { type: "error", title: `Invalid ${mode.label}` });
+        return { ok: false };
     }
 }
 
-function isValidJson() {
+function refreshButtons() {
+    const empty = rawJsonData().trim() === "";
+    for (const button of actionButtons) {
+        button.disabled = empty;
+    }
+}
+
+/* ------------------------------------------------------------------ actions */
+
+async function prettyPrint() {
+    const result = await parse();
+    if (result.ok) {
+        field.value = result.codec.stringify(result.value, INDENT);
+    }
+}
+
+async function minify() {
+    const result = await parse();
+    if (result.ok) {
+        field.value = result.codec.stringify(result.value, undefined);
+    }
+}
+
+async function validate() {
+    const mode = currentMode();
+    const result = await parse();
+    if (result.ok) {
+        toast(`Your input is valid ${mode.label}.`, { type: "success", title: `Valid ${mode.label}` });
+    }
+}
+
+async function copy() {
+    const text = rawJsonData();
     try {
-        JSON.parse(rawJsonData())
-        return true
+        await navigator.clipboard.writeText(text);
+        toast("Copied to clipboard.", { type: "success" });
     } catch (error) {
-        console.log(error)
-        return false
+        // Fallback for non-secure contexts / older browsers.
+        field.select();
+        const ok = document.execCommand("copy");
+        field.setSelectionRange(0, 0);
+        field.blur();
+        toast(ok ? "Copied to clipboard." : "Could not copy to clipboard.", {
+            type: ok ? "success" : "error",
+        });
     }
 }
 
-function isValidJson5() {
-    try {
-        JSON5.parse(rawJsonData())
-        return true
-    } catch (error) {
-        console.log(error)
-        return false
-    }
+function download() {
+    const defaultName = `json-tools-${Math.round(Date.now() / 1000)}`;
+    const input = window.prompt("File name", defaultName);
+    if (input === null) return; // cancelled
+    const name = (input.trim() || defaultName).replace(/\.json$/i, "");
+
+    const blob = new Blob([rawJsonData()], { type: "application/json;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${name}.json`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+    toast(`Downloaded ${name}.json`, { type: "success" });
 }
 
-function parseJson() {
-    try {
-        return JSON.parse(rawJsonData())
-    } catch (error) {
-        console.log(error)
-        validateJson5()
-        return false
-    }
+function clear() {
+    field.value = "";
+    refreshButtons();
+    field.focus();
 }
 
-function parseJson5() {
-    try {
-        return JSON5.parse(rawJsonData())
-    } catch (error) {
-        console.log(error)
-        validateJson5()
-        return false
-    }
+const handlers = { pretty: prettyPrint, minify, validate, copy, download, clear };
+
+/* ------------------------------------------------------------------ theming */
+
+function applyTheme(theme) {
+    document.documentElement.setAttribute("data-theme", theme);
 }
 
-function prettyPrintJson() {
-    if (isValidJson() && parseJson() !== false) {
-        document.getElementById(`jsonField`).value = JSON.stringify(parseJson(rawJsonData()), undefined, 2)
-    } else {
-        validateJson()
-    }
+function resolveInitialTheme() {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-function prettyPrintJson5() {
-    if (isValidJson5() && parseJson5() !== false) {
-        document.getElementById(`jsonField`).value = JSON5.stringify(parseJson5(rawJsonData()), undefined, 2)
-    } else {
-        validateJson5()
-    }
+function toggleTheme() {
+    const next = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
+    applyTheme(next);
+    localStorage.setItem(THEME_KEY, next);
 }
 
-function minifyJson() {
-    if (isValidJson() === true && parseJson() !== false) {
-        document.getElementById(`jsonField`).value = JSON.stringify(parseJson(rawJsonData()))
-    } else {
-        validateJson()
-    }
+/* ----------------------------------------------------------------- drag/drop */
+
+function loadFile(file) {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+        field.value = reader.result;
+        refreshButtons();
+        toast(`Loaded ${file.name}`, { type: "success" });
+    };
+    reader.onerror = () => toast("Could not read that file.", { type: "error" });
+    reader.readAsText(file);
 }
 
-function minifyJson5() {
-    if (isValidJson5() === true && parseJson5() !== false) {
-        document.getElementById(`jsonField`).value = JSON5.stringify(parseJson5(rawJsonData()))
-    } else {
-        validateJson5()
-    }
+function setupDropZone() {
+    let depth = 0;
+    const show = () => dropZone.classList.add("is-dragover");
+    const hide = () => dropZone.classList.remove("is-dragover");
+
+    dropZone.addEventListener("dragenter", (e) => {
+        e.preventDefault();
+        depth += 1;
+        show();
+    });
+    dropZone.addEventListener("dragover", (e) => e.preventDefault());
+    dropZone.addEventListener("dragleave", () => {
+        depth = Math.max(0, depth - 1);
+        if (depth === 0) hide();
+    });
+    dropZone.addEventListener("drop", (e) => {
+        e.preventDefault();
+        depth = 0;
+        hide();
+        loadFile(e.dataTransfer.files[0]);
+    });
 }
 
-function downloadJson() {
-    let element = document.createElement(`a`)
-    try {
-        element.setAttribute(`href`, `data:application/json;charset=utf-8,` + encodeURIComponent(rawJsonData()))
-        element.setAttribute(`download`, currentTime() + `.json`)
-        element.style.display = `none`
-        document.body.appendChild(element)
-        element.click()
-    } catch (error) {
-        alert(error)
-    }
+/* -------------------------------------------------------------------- wiring */
+
+applyTheme(resolveInitialTheme());
+refreshButtons();
+setupDropZone();
+
+themeToggle.addEventListener("click", toggleTheme);
+field.addEventListener("input", refreshButtons);
+
+for (const button of actionButtons) {
+    button.addEventListener("click", () => {
+        const action = handlers[button.dataset.action];
+        if (action) action();
+    });
 }
-
-function copyText() {
-    document.getElementById(`jsonField`).select()
-    document.execCommand(`copy`)
-}
-
-function blankText() {
-    const btnList = $(`.btn`)
-    const flag = rawJsonData() === ``
-    for (let i in btnList) {
-        btnList[i].disabled = flag
-    }
-}
-
-function clearText() {
-    document.getElementById(`jsonField`).value = ``
-    blankText()
-}
-
-function currentTime() {
-    return Math.round(new Date().getTime() / 1000).toString()
-}
-
-function dropJSON(targetEl, callback) {
-    targetEl.addEventListener(`dragenter`, function (e) { e.preventDefault() })
-    targetEl.addEventListener(`dragover`, function (e) { e.preventDefault() })
-
-    targetEl.addEventListener(`drop`, function (event) {
-        var reader = new FileReader()
-        reader.onloadend = function () {
-            var data = this.result
-            callback(data)
-        }
-        reader.readAsText(event.dataTransfer.files[0])
-        event.preventDefault()
-    })
-}
-
-dropJSON(
-    document.getElementById(`body`),
-    function (data) {
-        document.getElementById(`jsonField`).value = data
-        blankText()
-    }
-)

--- a/style.css
+++ b/style.css
@@ -1,16 +1,403 @@
-body {
-    position: absolute;
-    width: 100%;
-    height: 20px;
-    top: 0%;
-    margin-top: -10px;
-    bottom: 0%;
-    text-align: center;
-    font-family: "Consolas";
+:root {
+    color-scheme: light dark;
+
+    --bg: #f4f5f7;
+    --surface: #ffffff;
+    --surface-2: #eceef1;
+    --border: #d8dce2;
+    --text: #1c2330;
+    --text-muted: #5a6473;
+    --accent: #2f6fed;
+    --accent-contrast: #ffffff;
+    --accent-soft: rgba(47, 111, 237, 0.12);
+    --success: #1f9d55;
+    --error: #d6453d;
+    --shadow: 0 10px 30px rgba(18, 26, 41, 0.08);
+    --radius: 12px;
+    --radius-sm: 8px;
+    --mono: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
-textarea {
-    overflow: auto;
-    resize: none;
-    min-height: 75vh;
+[data-theme="dark"] {
+    --bg: #11151c;
+    --surface: #1a2029;
+    --surface-2: #222a35;
+    --border: #2c3644;
+    --text: #e7ecf3;
+    --text-muted: #97a2b2;
+    --accent: #5b8def;
+    --accent-contrast: #0c1018;
+    --accent-soft: rgba(91, 141, 239, 0.18);
+    --success: #46c47c;
+    --error: #f0746b;
+    --shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    min-height: 100%;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--sans);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+.app {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: clamp(1rem, 3vw, 2.5rem) clamp(1rem, 4vw, 2rem) 2rem;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.app-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.app-title {
+    margin: 0;
+    font-size: clamp(1.5rem, 4vw, 2rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+.app-subtitle {
+    margin: 0.25rem 0 1.25rem;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+}
+
+.app-subtitle strong {
+    color: var(--text);
+    font-weight: 600;
+}
+
+/* Theme toggle */
+.icon-button {
+    display: inline-grid;
+    place-items: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    transition: background 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
+}
+
+.icon-button:hover {
+    background: var(--surface-2);
+}
+
+.icon-button:active {
+    transform: scale(0.94);
+}
+
+.theme-icon {
+    width: 20px;
+    height: 20px;
+    background: currentColor;
+    -webkit-mask: center / contain no-repeat;
+    mask: center / contain no-repeat;
+    /* moon */
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z'/%3E%3C/svg%3E");
+}
+
+[data-theme="dark"] .theme-icon {
+    /* sun */
+    -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round'%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3Cpath d='M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.5 1.5M17.5 17.5L19 19M19 5l-1.5 1.5M6.5 17.5L5 19'/%3E%3C/svg%3E");
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round'%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3Cpath d='M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.5 1.5M17.5 17.5L19 19M19 5l-1.5 1.5M6.5 17.5L5 19'/%3E%3C/svg%3E");
+}
+
+/* Toolbar */
+.toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.85rem;
+}
+
+.mode-toggle {
+    display: inline-flex;
+    margin: 0;
+    padding: 4px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface-2);
+}
+
+.mode-option {
+    position: relative;
+    cursor: pointer;
+}
+
+.mode-option input {
+    position: absolute;
+    opacity: 0;
+    inset: 0;
+    margin: 0;
+    cursor: pointer;
+}
+
+.mode-option span {
+    display: block;
+    padding: 0.4rem 1rem;
+    border-radius: 999px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.mode-option input:checked + span {
+    background: var(--surface);
+    color: var(--text);
+    box-shadow: var(--shadow);
+}
+
+.mode-option input:focus-visible + span {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.button {
+    appearance: none;
+    border: 1px solid transparent;
+    background: var(--accent);
+    color: var(--accent-contrast);
+    font: inherit;
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0.5rem 1rem;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: filter 0.15s ease, transform 0.1s ease, background 0.15s ease, opacity 0.15s ease;
+}
+
+.button:hover:not(:disabled) {
+    filter: brightness(1.07);
+}
+
+.button:active:not(:disabled) {
+    transform: translateY(1px);
+}
+
+.button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.button-ghost {
+    background: transparent;
+    color: var(--text);
+    border-color: var(--border);
+}
+
+.button-ghost:hover:not(:disabled) {
+    background: var(--surface-2);
+    filter: none;
+}
+
+/* Editor */
+.editor {
+    position: relative;
+    flex: 1;
+    display: flex;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--surface);
+    box-shadow: var(--shadow);
+    overflow: hidden;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.editor.is-dragover {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.editor-input {
+    flex: 1;
+    width: 100%;
+    min-height: 55vh;
+    resize: vertical;
+    border: 0;
+    outline: none;
+    padding: 1rem 1.1rem;
+    background: transparent;
+    color: var(--text);
+    font-family: var(--mono);
+    font-size: 0.92rem;
+    line-height: 1.6;
+    tab-size: 2;
+}
+
+.editor-input::placeholder {
+    color: var(--text-muted);
+}
+
+.drop-overlay {
+    position: absolute;
+    inset: 0;
+    display: none;
+    place-items: center;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 1.1rem;
+    pointer-events: none;
+}
+
+.editor.is-dragover .drop-overlay {
+    display: grid;
+}
+
+/* Footer */
+.app-footer {
+    margin-top: 1.25rem;
+    text-align: center;
+}
+
+/* Toasts */
+.toasts {
+    position: fixed;
+    bottom: 1.25rem;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 100;
+    width: min(92vw, 420px);
+    pointer-events: none;
+}
+
+.toast {
+    pointer-events: auto;
+    padding: 0.7rem 1rem;
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--accent);
+    box-shadow: var(--shadow);
+    font-size: 0.9rem;
+    animation: toast-in 0.18s ease;
+}
+
+.toast.is-leaving {
+    animation: toast-out 0.2s ease forwards;
+}
+
+.toast--success {
+    border-left-color: var(--success);
+}
+
+.toast--error {
+    border-left-color: var(--error);
+}
+
+.toast__title {
+    font-weight: 700;
+    margin: 0 0 0.1rem;
+}
+
+.toast__body {
+    margin: 0;
+    color: var(--text-muted);
+    word-break: break-word;
+    white-space: pre-wrap;
+}
+
+@keyframes toast-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes toast-out {
+    to { opacity: 0; transform: translateY(8px); }
+}
+
+/* Accessibility helpers */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: var(--accent-contrast);
+    padding: 0.5rem 1rem;
+    border-radius: 0 0 var(--radius-sm) 0;
+    z-index: 200;
+}
+
+.skip-link:focus {
+    left: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.001ms !important;
+        transition-duration: 0.001ms !important;
+    }
+}
+
+@media (max-width: 600px) {
+    .toolbar {
+        justify-content: stretch;
+    }
+
+    .mode-toggle {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .actions {
+        width: 100%;
+    }
+
+    .actions .button {
+        flex: 1 1 auto;
+    }
 }


### PR DESCRIPTION
Rewrite the site as dependency-light vanilla JS (ES modules) and handwritten
CSS, dropping jQuery and Bootstrap. Preserve all existing functionality
(pretty print, minify, validate, copy, download, clear, drag-and-drop for
both JSON and JSON5) while improving the experience:

- Light/dark theme toggle that persists and follows the OS preference
- Non-blocking toast notifications instead of blocking alert() dialogs
- Clipboard API for copy (with a graceful fallback) plus confirmation
- Custom download file name
- Responsive layout; fixes the broken absolute body positioning
- JSON/JSON5 collapsed into a single mode toggle + shared action buttons
- Fixes duplicate element IDs and removes inline event handlers
- JSON5 loaded lazily on first use, so JSON features work with no network
  dependency and a CDN hiccup only affects JSON5 mode

Remains a zero-build static site, deployable to GitHub Pages as-is.