### PR TITLE
Redesign theme with iOS-style Liquid Glass aesthetic

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
 </head>
 
 <body>
+    <div class="ambient" aria-hidden="true"></div>
+
     <a class="skip-link" href="#jsonField">Skip to editor</a>
 
     <div class="app">

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 :root {
     color-scheme: light dark;
 
-    --bg: #f4f5f7;
+    --bg: #eef1f6;
     --surface: #ffffff;
     --surface-2: #eceef1;
     --border: #d8dce2;
@@ -13,14 +13,31 @@
     --success: #1f9d55;
     --error: #d6453d;
     --shadow: 0 10px 30px rgba(18, 26, 41, 0.08);
-    --radius: 12px;
-    --radius-sm: 8px;
+
+    /* Liquid Glass tokens */
+    --glass-bg: rgba(255, 255, 255, 0.55);
+    --glass-bg-strong: rgba(255, 255, 255, 0.78);
+    --glass-border: rgba(255, 255, 255, 0.7);
+    --glass-highlight: rgba(255, 255, 255, 0.85);
+    --glass-blur: 18px;
+    --glass-shadow: 0 8px 24px rgba(18, 26, 41, 0.12), 0 2px 6px rgba(18, 26, 41, 0.06);
+    --accent-glass: rgba(47, 111, 237, 0.82);
+    --accent-glass-strong: rgba(47, 111, 237, 0.95);
+
+    /* Soft ambient backdrop blobs */
+    --blob-1: rgba(99, 152, 255, 0.35);
+    --blob-2: rgba(126, 110, 245, 0.28);
+    --blob-3: rgba(64, 196, 198, 0.26);
+
+    --radius: 20px;
+    --radius-sm: 14px;
+    --radius-pill: 999px;
     --mono: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
     --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
 [data-theme="dark"] {
-    --bg: #11151c;
+    --bg: #0c0f16;
     --surface: #1a2029;
     --surface-2: #222a35;
     --border: #2c3644;
@@ -32,6 +49,19 @@
     --success: #46c47c;
     --error: #f0746b;
     --shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+
+    /* Liquid Glass tokens */
+    --glass-bg: rgba(26, 32, 41, 0.45);
+    --glass-bg-strong: rgba(40, 49, 63, 0.7);
+    --glass-border: rgba(255, 255, 255, 0.12);
+    --glass-highlight: rgba(255, 255, 255, 0.18);
+    --glass-shadow: 0 12px 32px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.35);
+    --accent-glass: rgba(91, 141, 239, 0.8);
+    --accent-glass-strong: rgba(91, 141, 239, 0.92);
+
+    --blob-1: rgba(64, 104, 200, 0.4);
+    --blob-2: rgba(108, 84, 220, 0.34);
+    --blob-3: rgba(40, 150, 160, 0.3);
 }
 
 * {
@@ -51,6 +81,31 @@ body {
     font-family: var(--sans);
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
+}
+
+/* Soft ambient backdrop for the Liquid Glass surfaces to refract */
+.ambient {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    pointer-events: none;
+    background:
+        radial-gradient(42rem 42rem at 12% 18%, var(--blob-1), transparent 60%),
+        radial-gradient(38rem 38rem at 88% 22%, var(--blob-2), transparent 60%),
+        radial-gradient(46rem 46rem at 50% 96%, var(--blob-3), transparent 62%),
+        var(--bg);
+    animation: ambient-drift 32s ease-in-out infinite alternate;
+}
+
+@keyframes ambient-drift {
+    from {
+        transform: translate3d(-2%, -1%, 0) scale(1.05);
+    }
+
+    to {
+        transform: translate3d(2%, 1.5%, 0) scale(1.12);
+    }
 }
 
 .app {
@@ -94,15 +149,18 @@ body {
     width: 42px;
     height: 42px;
     border-radius: 50%;
-    border: 1px solid var(--border);
-    background: var(--surface);
+    border: 1px solid var(--glass-border);
+    background: var(--glass-bg);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
     color: var(--text);
     cursor: pointer;
-    transition: background 0.15s ease, transform 0.15s ease, border-color 0.15s ease;
+    transition: background 0.15s ease, transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .icon-button:hover {
-    background: var(--surface-2);
+    background: var(--glass-bg-strong);
 }
 
 .icon-button:active {
@@ -140,9 +198,12 @@ body {
     display: inline-flex;
     margin: 0;
     padding: 4px;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    background: var(--surface-2);
+    border: 1px solid var(--glass-border);
+    border-radius: var(--radius-pill);
+    background: var(--glass-bg);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
 }
 
 .mode-option {
@@ -161,17 +222,17 @@ body {
 .mode-option span {
     display: block;
     padding: 0.4rem 1rem;
-    border-radius: 999px;
+    border-radius: var(--radius-pill);
     font-size: 0.9rem;
     font-weight: 600;
     color: var(--text-muted);
-    transition: background 0.15s ease, color 0.15s ease;
+    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .mode-option input:checked + span {
-    background: var(--surface);
+    background: var(--glass-bg-strong);
     color: var(--text);
-    box-shadow: var(--shadow);
+    box-shadow: 0 2px 8px rgba(18, 26, 41, 0.16), inset 0 1px 0 var(--glass-highlight);
 }
 
 .mode-option input:focus-visible + span {
@@ -187,20 +248,24 @@ body {
 
 .button {
     appearance: none;
-    border: 1px solid transparent;
-    background: var(--accent);
+    border: 1px solid var(--accent-glass-strong);
+    background: var(--accent-glass);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    box-shadow: var(--glass-shadow), inset 0 1px 0 rgba(255, 255, 255, 0.4);
     color: var(--accent-contrast);
     font: inherit;
     font-size: 0.9rem;
     font-weight: 600;
-    padding: 0.5rem 1rem;
-    border-radius: var(--radius-sm);
+    padding: 0.5rem 1.1rem;
+    border-radius: var(--radius-pill);
     cursor: pointer;
-    transition: filter 0.15s ease, transform 0.1s ease, background 0.15s ease, opacity 0.15s ease;
+    transition: filter 0.15s ease, transform 0.1s ease, background 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
 }
 
 .button:hover:not(:disabled) {
-    filter: brightness(1.07);
+    background: var(--accent-glass-strong);
+    filter: brightness(1.05);
 }
 
 .button:active:not(:disabled) {
@@ -218,13 +283,14 @@ body {
 }
 
 .button-ghost {
-    background: transparent;
+    background: var(--glass-bg);
     color: var(--text);
-    border-color: var(--border);
+    border-color: var(--glass-border);
+    box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
 }
 
 .button-ghost:hover:not(:disabled) {
-    background: var(--surface-2);
+    background: var(--glass-bg-strong);
     filter: none;
 }
 
@@ -233,17 +299,19 @@ body {
     position: relative;
     flex: 1;
     display: flex;
-    border: 1px solid var(--border);
+    border: 1px solid var(--glass-border);
     border-radius: var(--radius);
-    background: var(--surface);
-    box-shadow: var(--shadow);
+    background: var(--glass-bg);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
     overflow: hidden;
     transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .editor.is-dragover {
     border-color: var(--accent);
-    box-shadow: 0 0 0 3px var(--accent-soft);
+    box-shadow: var(--glass-shadow), 0 0 0 3px var(--accent-soft);
 }
 
 .editor-input {
@@ -272,6 +340,8 @@ body {
     display: none;
     place-items: center;
     background: var(--accent-soft);
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
     color: var(--accent);
     font-weight: 700;
     font-size: 1.1rem;
@@ -306,11 +376,13 @@ body {
     pointer-events: auto;
     padding: 0.7rem 1rem;
     border-radius: var(--radius-sm);
-    background: var(--surface);
+    background: var(--glass-bg-strong);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
     color: var(--text);
-    border: 1px solid var(--border);
+    border: 1px solid var(--glass-border);
     border-left: 4px solid var(--accent);
-    box-shadow: var(--shadow);
+    box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
     font-size: 0.9rem;
     animation: toast-in 0.18s ease;
 }
@@ -380,6 +452,48 @@ body {
     * {
         animation-duration: 0.001ms !important;
         transition-duration: 0.001ms !important;
+    }
+
+    .ambient {
+        animation: none;
+    }
+}
+
+/*
+ * Fallback for browsers without backdrop-filter support: drop the
+ * translucency and use the existing opaque surfaces so text stays readable.
+ */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+
+    .editor,
+    .mode-toggle,
+    .icon-button,
+    .toast {
+        background: var(--surface);
+        box-shadow: var(--shadow);
+    }
+
+    .mode-option input:checked + span {
+        background: var(--surface-2);
+    }
+
+    .button {
+        background: var(--accent);
+        border-color: transparent;
+    }
+
+    .button:hover:not(:disabled) {
+        background: var(--accent);
+    }
+
+    .button-ghost {
+        background: transparent;
+        border-color: var(--border);
+        box-shadow: none;
+    }
+
+    .button-ghost:hover:not(:disabled) {
+        background: var(--surface-2);
     }
 }
 


### PR DESCRIPTION
Add frosted-glass styling across the UI: translucent backdrop-blur panels
with specular edge highlights and layered depth over a soft ambient
backdrop. Applies to the editor, toolbar, buttons, theme toggle, mode
toggle, and toasts in both light and dark themes.

- Introduce glass design tokens (--glass-bg, --glass-border, --glass-blur,
  --glass-shadow, accent glass) and larger iOS-style radii
- Add a fixed .ambient backdrop with soft drifting color blobs
- Provide an @supports fallback to opaque surfaces for browsers without
  backdrop-filter, and pause the ambient drift under reduced-motion