### PR TITLE
Add 'Load example' button with mode-aware sample data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Accepts [JSON](https://www.json.org/) or [JSON5](https://json5.org/) format.
 - Validate
 - Copy to clipboard
 - Download (choose your own file name)
+- Load example (mode-aware sample data)
 - Clear
 - Drag 'n' drop files
 - Light & dark theme (remembers your choice, follows your system by default)
@@ -47,4 +48,3 @@ python3 -m http.server 8000
 - Scrape URL
 - Syntax highlighting / code editor
 - Compare two JSON inputs
-- Load example JSON

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
             "Validate JSON and JSON5",
             "Copy to clipboard",
             "Download as a file",
+            "Load example JSON",
             "Drag and drop files",
             "Light and dark theme"
         ]
@@ -102,6 +103,7 @@
                 <button type="button" class="button" data-action="validate" disabled>Validate</button>
                 <button type="button" class="button" data-action="copy" disabled>Copy</button>
                 <button type="button" class="button" data-action="download" disabled>Download</button>
+                <button type="button" class="button button-ghost" data-action="example">Example</button>
                 <button type="button" class="button button-ghost" data-action="clear" disabled>Clear</button>
             </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -2,6 +2,48 @@ const INDENT = 2;
 const THEME_KEY = "json-tools-theme";
 const JSON5_URL = "https://cdn.jsdelivr.net/npm/json5@2/+esm";
 
+// Sample data so a first-time visitor can try the tool without hunting for JSON.
+// The JSON5 variant uses the same data but leans on JSON5-only syntax (a comment,
+// unquoted keys, single quotes, a trailing comma) to show off what the mode allows.
+const EXAMPLE_JSON = `{
+    "name": "JSON Tools",
+    "version": "1.0.0",
+    "private": false,
+    "tags": ["json", "json5", "formatter"],
+    "author": {
+        "name": "Thomas Chaplin",
+        "url": "https://json.thomaschaplin.me"
+    },
+    "features": {
+        "prettyPrint": true,
+        "minify": true,
+        "validate": true,
+        "offline": true
+    },
+    "stars": 42,
+    "license": null
+}`;
+
+const EXAMPLE_JSON5 = `{
+    // JSON5 allows comments, unquoted keys, single quotes and trailing commas.
+    name: 'JSON Tools',
+    version: '1.0.0',
+    private: false,
+    tags: ['json', 'json5', 'formatter'],
+    author: {
+        name: 'Thomas Chaplin',
+        url: 'https://json.thomaschaplin.me',
+    },
+    features: {
+        prettyPrint: true,
+        minify: true,
+        validate: true,
+        offline: true,
+    },
+    stars: 42,
+    license: null,
+}`;
+
 // JSON5 is loaded lazily from a CDN the first time it is needed, so the app
 // (and all JSON-only features) work instantly with no network dependency.
 let json5Promise;
@@ -93,9 +135,13 @@ async function parse() {
     }
 }
 
+// The "Example" button stays enabled on an empty editor — loading a sample is the
+// one action that makes sense with no input yet.
+const toggleButtons = actionButtons.filter((button) => button.dataset.action !== "example");
+
 function refreshButtons() {
     const empty = rawJsonData().trim() === "";
-    for (const button of actionButtons) {
+    for (const button of toggleButtons) {
         button.disabled = empty;
     }
 }
@@ -165,7 +211,17 @@ function clear() {
     field.focus();
 }
 
-const handlers = { pretty: prettyPrint, minify, validate, copy, download, clear };
+function loadExample() {
+    if (rawJsonData().trim() !== "" && !window.confirm("Replace the current contents with example data?")) {
+        return; // keep the user's input
+    }
+    field.value = currentMode().label === "JSON5" ? EXAMPLE_JSON5 : EXAMPLE_JSON;
+    refreshButtons();
+    field.focus();
+    toast("Loaded example data.", { type: "success" });
+}
+
+const handlers = { pretty: prettyPrint, minify, validate, copy, download, example: loadExample, clear };
 
 /* ------------------------------------------------------------------ theming */
 


### PR DESCRIPTION
Adds an Example button that fills the editor with a small sample so the
tool is usable on first load. The sample respects the active format mode:
a clean JSON sample in JSON mode, and a JSON5 sample (comment, unquoted
keys, single quotes, trailing comma) in JSON5 mode. The button stays
enabled on an empty editor and confirms before overwriting existing input.

https://claude.ai/code/session_01Bpqkkxb3wvNV1knhQPD9Nn