### PR TITLE
Add iOS-style gestures and animations to Liquid Glass theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="author" content="Thomas Chaplin">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="description" content="A fast, free tool to format, minify, validate, copy and download JSON and JSON5.">
     <meta name="color-scheme" content="light dark">
     <meta name="theme-color" content="#eef1f6" media="(prefers-color-scheme: light)">

--- a/main.js
+++ b/main.js
@@ -90,6 +90,56 @@ function rawJsonData() {
     return field.value;
 }
 
+// A subtle vibration on interaction. Progressive enhancement — supported on
+// Android/Chrome and silently ignored where the Vibration API is unavailable
+// (notably iOS Safari), so calling it is always safe.
+function haptic(ms = 8) {
+    navigator.vibrate?.(ms);
+}
+
+// Let an element be flicked away with a vertical swipe, iOS banner style. The
+// finger is tracked upward 1:1 (the dismiss direction) and damped downward, with
+// opacity fading as it travels. Past a small threshold the swipe commits and
+// `dismiss` is called; otherwise it springs back to rest.
+function makeSwipeable(el, dismiss) {
+    let startY = 0;
+    let dy = 0;
+    let dragging = false;
+
+    el.addEventListener("pointerdown", (e) => {
+        dragging = true;
+        startY = e.clientY;
+        dy = 0;
+        el.setPointerCapture(e.pointerId);
+        el.style.transition = "none";
+    });
+
+    el.addEventListener("pointermove", (e) => {
+        if (!dragging) return;
+        dy = e.clientY - startY;
+        if (dy > 0) dy *= 0.3; // resist dragging the wrong way
+        el.style.transform = `translateY(${dy}px)`;
+        el.style.opacity = String(Math.max(0, 1 + Math.min(0, dy) / 120));
+    });
+
+    const end = () => {
+        if (!dragging) return;
+        dragging = false;
+        el.style.transition = "";
+        if (dy < -40) {
+            haptic(6);
+            dismiss();
+        } else {
+            // Spring back to its resting position.
+            el.style.transform = "";
+            el.style.opacity = "";
+        }
+    };
+
+    el.addEventListener("pointerup", end);
+    el.addEventListener("pointercancel", end);
+}
+
 function toast(message, { type = "info", title } = {}) {
     const el = document.createElement("div");
     el.className = `toast toast--${type}`;
@@ -105,11 +155,16 @@ function toast(message, { type = "info", title } = {}) {
     el.appendChild(body);
     toasts.appendChild(el);
 
+    let removed = false;
     const remove = () => {
+        if (removed) return; // guard against the auto-timer and a swipe both firing
+        removed = true;
+        clearTimeout(timer);
         el.classList.add("is-leaving");
         el.addEventListener("animationend", () => el.remove(), { once: true });
     };
-    setTimeout(remove, type === "error" ? 6000 : 3000);
+    const timer = setTimeout(remove, type === "error" ? 6000 : 3000);
+    makeSwipeable(el, remove);
 }
 
 // Parse with the active mode, surfacing errors as toasts. Returns a result
@@ -237,8 +292,12 @@ function resolveInitialTheme() {
 
 function toggleTheme() {
     const next = document.documentElement.getAttribute("data-theme") === "dark" ? "light" : "dark";
+    haptic();
+    // Spin/shrink the icon out, swap the mask, then let it spring back in.
+    themeToggle.classList.add("is-toggling");
     applyTheme(next);
     localStorage.setItem(THEME_KEY, next);
+    setTimeout(() => themeToggle.classList.remove("is-toggling"), 200);
 }
 
 /* ----------------------------------------------------------------- drag/drop */
@@ -297,7 +356,13 @@ window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e)
 
 for (const button of actionButtons) {
     button.addEventListener("click", () => {
+        haptic(button.dataset.action === "clear" ? 12 : 8);
         const action = handlers[button.dataset.action];
         if (action) action();
     });
+}
+
+// A light tick when switching format mode, matching the sliding-pill motion.
+for (const radio of document.querySelectorAll('input[name="mode"]')) {
+    radio.addEventListener("change", () => haptic(6));
 }

--- a/style.css
+++ b/style.css
@@ -32,6 +32,12 @@
     --radius: 20px;
     --radius-sm: 14px;
     --radius-pill: 999px;
+
+    /* iOS-style motion curves */
+    --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);    /* overshoot — presses, toast entrance */
+    --ease-ios: cubic-bezier(0.32, 0.72, 0, 1);          /* iOS standard ease — sliding pill */
+    --ease-out-ios: cubic-bezier(0.16, 1, 0.3, 1);       /* decelerate — settle / spring-back */
+
     --mono: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", monospace;
     --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
@@ -75,12 +81,31 @@ body {
     min-height: 100%;
 }
 
+html {
+    /* Stop iOS from auto-inflating font sizes on orientation change. */
+    -webkit-text-size-adjust: 100%;
+}
+
 body {
     background: var(--bg);
     color: var(--text);
     font-family: var(--sans);
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
+    /* Keep the rubber-band scroll from bleeding past the page like a native app. */
+    overscroll-behavior-y: contain;
+}
+
+/* Native-feeling touch targets: no grey tap flash, no accidental text
+   selection on double-tap, no 300ms click delay. */
+.button,
+.icon-button,
+.mode-option,
+.toast {
+    -webkit-tap-highlight-color: transparent;
+    -webkit-user-select: none;
+    user-select: none;
+    touch-action: manipulation;
 }
 
 /* Soft ambient backdrop for the Liquid Glass surfaces to refract */
@@ -156,7 +181,7 @@ body {
     box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
     color: var(--text);
     cursor: pointer;
-    transition: background 0.15s ease, transform 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+    transition: background 0.15s ease, transform 0.3s var(--ease-spring), border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .icon-button:hover {
@@ -164,13 +189,15 @@ body {
 }
 
 .icon-button:active {
-    transform: scale(0.94);
+    transform: scale(0.88);
+    transition-duration: 0.06s;
 }
 
 .theme-icon {
     width: 20px;
     height: 20px;
     background: currentColor;
+    transition: transform 0.4s var(--ease-spring);
     -webkit-mask: center / contain no-repeat;
     mask: center / contain no-repeat;
     /* moon */
@@ -184,6 +211,12 @@ body {
     mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round'%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3Cpath d='M12 2v2M12 20v2M2 12h2M20 12h2M5 5l1.5 1.5M17.5 17.5L19 19M19 5l-1.5 1.5M6.5 17.5L5 19'/%3E%3C/svg%3E");
 }
 
+/* During a theme switch the icon spins and shrinks out, then the new mask
+   springs back in — a quick, native-feeling swap. */
+.icon-button.is-toggling .theme-icon {
+    transform: rotate(180deg) scale(0);
+}
+
 /* Toolbar */
 .toolbar {
     display: flex;
@@ -195,6 +228,7 @@ body {
 }
 
 .mode-toggle {
+    position: relative;
     display: inline-flex;
     margin: 0;
     padding: 4px;
@@ -206,8 +240,30 @@ body {
     box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
 }
 
+/* Sliding thumb — the single highlight that glides between the two options,
+   like an iOS segmented control. */
+.mode-toggle::before {
+    content: "";
+    position: absolute;
+    top: 4px;
+    bottom: 4px;
+    left: 4px;
+    width: calc(50% - 4px);
+    border-radius: var(--radius-pill);
+    background: var(--glass-bg-strong);
+    box-shadow: 0 2px 8px rgba(18, 26, 41, 0.16), inset 0 1px 0 var(--glass-highlight);
+    transition: transform 0.34s var(--ease-ios);
+    pointer-events: none;
+}
+
+.mode-toggle:has(.mode-option:last-child input:checked)::before {
+    transform: translateX(100%);
+}
+
 .mode-option {
     position: relative;
+    flex: 1;
+    text-align: center;
     cursor: pointer;
 }
 
@@ -220,19 +276,19 @@ body {
 }
 
 .mode-option span {
+    position: relative;
+    z-index: 1;
     display: block;
     padding: 0.4rem 1rem;
     border-radius: var(--radius-pill);
     font-size: 0.9rem;
     font-weight: 600;
     color: var(--text-muted);
-    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+    transition: color 0.2s var(--ease-ios);
 }
 
 .mode-option input:checked + span {
-    background: var(--glass-bg-strong);
     color: var(--text);
-    box-shadow: 0 2px 8px rgba(18, 26, 41, 0.16), inset 0 1px 0 var(--glass-highlight);
 }
 
 .mode-option input:focus-visible + span {
@@ -260,7 +316,7 @@ body {
     padding: 0.5rem 1.1rem;
     border-radius: var(--radius-pill);
     cursor: pointer;
-    transition: filter 0.15s ease, transform 0.1s ease, background 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+    transition: filter 0.15s ease, transform 0.22s var(--ease-spring), background 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
 }
 
 .button:hover:not(:disabled) {
@@ -269,7 +325,8 @@ body {
 }
 
 .button:active:not(:disabled) {
-    transform: translateY(1px);
+    transform: scale(0.95);
+    transition-duration: 0.06s;
 }
 
 .button:focus-visible {
@@ -328,6 +385,8 @@ body {
     font-size: 0.92rem;
     line-height: 1.6;
     tab-size: 2;
+    /* Native momentum scrolling for long documents on touch devices. */
+    -webkit-overflow-scrolling: touch;
 }
 
 .editor-input::placeholder {
@@ -337,7 +396,7 @@ body {
 .drop-overlay {
     position: absolute;
     inset: 0;
-    display: none;
+    display: grid;
     place-items: center;
     background: var(--accent-soft);
     -webkit-backdrop-filter: blur(6px);
@@ -346,16 +405,22 @@ body {
     font-weight: 700;
     font-size: 1.1rem;
     pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transform: scale(0.96);
+    transition: opacity 0.25s var(--ease-out-ios), transform 0.35s var(--ease-spring), visibility 0.25s;
 }
 
 .editor.is-dragover .drop-overlay {
-    display: grid;
+    opacity: 1;
+    visibility: visible;
+    transform: scale(1);
 }
 
 /* Toasts */
 .toasts {
     position: fixed;
-    bottom: 1.25rem;
+    top: calc(env(safe-area-inset-top, 0px) + 0.75rem);
     left: 50%;
     transform: translateX(-50%);
     display: flex;
@@ -378,11 +443,14 @@ body {
     border-left: 4px solid var(--accent);
     box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
     font-size: 0.9rem;
-    animation: toast-in 0.18s ease;
+    /* Vertical drag is handled in JS for swipe-to-dismiss. */
+    touch-action: pan-x;
+    cursor: grab;
+    animation: toast-in 0.5s var(--ease-spring);
 }
 
 .toast.is-leaving {
-    animation: toast-out 0.2s ease forwards;
+    animation: toast-out 0.3s var(--ease-out-ios) forwards;
 }
 
 .toast--success {
@@ -406,12 +474,12 @@ body {
 }
 
 @keyframes toast-in {
-    from { opacity: 0; transform: translateY(8px); }
+    from { opacity: 0; transform: translateY(-130%); }
     to { opacity: 1; transform: translateY(0); }
 }
 
 @keyframes toast-out {
-    to { opacity: 0; transform: translateY(8px); }
+    to { opacity: 0; transform: translateY(-130%); }
 }
 
 /* Accessibility helpers */
@@ -467,8 +535,9 @@ body {
         box-shadow: var(--shadow);
     }
 
-    .mode-option input:checked + span {
+    .mode-toggle::before {
         background: var(--surface-2);
+        box-shadow: none;
     }
 
     .button {


### PR DESCRIPTION
Layer native-feeling motion and gestures on top of the existing Liquid
Glass theme:

- Spring easing tokens shared across all interactions
- Buttery spring presses on buttons and the theme toggle (fast press,
  springy release)
- Sliding segmented control for the JSON/JSON5 mode toggle
- Theme toggle icon spins/springs as it swaps sun and moon
- Top banner notifications that drop in with a bounce and can be
  swiped up to dismiss
- Spring entrance for the drag-and-drop overlay
- Subtle haptics on taps, toggles and swipe-dismiss (progressive
  enhancement via the Vibration API)
- Touch niceties: no tap-highlight flash, no accidental selection,
  momentum scrolling, notch safe-area support

All additive over the existing zero-build vanilla stack; reduced-motion
preferences still collapse animations to instant.