### PR TITLE
Elevate UI to a bold Liquid Glass theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,13 +90,24 @@
 
 <body>
     <div class="ambient" aria-hidden="true"></div>
+    <div class="ambient-grain" aria-hidden="true"></div>
+
+    <!-- Liquid Glass lensing filter: a gentle turbulence displacement applied to
+         the editor's backdrop where supported, for a watery refraction. Purely a
+         progressive enhancement (see the @supports guard in style.css). -->
+    <svg width="0" height="0" aria-hidden="true" focusable="false" style="position:absolute">
+        <filter id="liquid-glass" x="-20%" y="-20%" width="140%" height="140%">
+            <feTurbulence type="fractalNoise" baseFrequency="0.008 0.012" numOctaves="2" seed="7" result="noise" />
+            <feDisplacementMap in="SourceGraphic" in2="noise" scale="14" xChannelSelector="R" yChannelSelector="G" />
+        </filter>
+    </svg>
 
     <a class="skip-link" href="#jsonField">Skip to editor</a>
 
     <div class="app">
         <header class="app-header">
             <h1 class="app-title">JSON Tools</h1>
-            <button type="button" id="themeToggle" class="icon-button" aria-label="Toggle colour theme" title="Toggle theme">
+            <button type="button" id="themeToggle" class="icon-button" data-glass aria-label="Toggle colour theme" title="Toggle theme">
                 <span class="theme-icon" aria-hidden="true"></span>
             </button>
         </header>
@@ -104,7 +115,7 @@
         <p class="app-subtitle">Format, minify and validate <strong>JSON</strong> or <strong>JSON5</strong> &mdash; right in your browser.</p>
 
         <div class="toolbar">
-            <fieldset class="mode-toggle" aria-label="Format mode">
+            <fieldset class="mode-toggle" data-glass aria-label="Format mode">
                 <legend class="visually-hidden">Format mode</legend>
                 <label class="mode-option">
                     <input type="radio" name="mode" value="json" checked>
@@ -117,18 +128,19 @@
             </fieldset>
 
             <div class="actions">
-                <button type="button" class="button" data-action="pretty" disabled>Pretty Print</button>
-                <button type="button" class="button" data-action="minify" disabled>Minify</button>
-                <button type="button" class="button" data-action="validate" disabled>Validate</button>
-                <button type="button" class="button" data-action="copy" disabled>Copy</button>
-                <button type="button" class="button" data-action="download" disabled>Download</button>
-                <button type="button" class="button button-ghost" data-action="example">Example</button>
-                <button type="button" class="button button-ghost" data-action="clear" disabled>Clear</button>
+                <button type="button" class="button" data-glass data-action="pretty" disabled>Pretty Print</button>
+                <button type="button" class="button" data-glass data-action="minify" disabled>Minify</button>
+                <button type="button" class="button" data-glass data-action="validate" disabled>Validate</button>
+                <button type="button" class="button" data-glass data-action="copy" disabled>Copy</button>
+                <button type="button" class="button" data-glass data-action="download" disabled>Download</button>
+                <button type="button" class="button button-ghost" data-glass data-action="example">Example</button>
+                <button type="button" class="button button-ghost" data-glass data-action="clear" disabled>Clear</button>
             </div>
         </div>
 
-        <div class="editor" id="dropZone">
+        <div class="editor" id="dropZone" data-glass>
             <div class="editor-input" id="jsonField"></div>
+            <div class="editor-sweep" aria-hidden="true"></div>
             <div class="drop-overlay" aria-hidden="true">Drop file to load</div>
         </div>
 

--- a/src/glass.ts
+++ b/src/glass.ts
@@ -1,0 +1,74 @@
+import { haptic } from "./toast";
+
+// Liquid Glass pointer interactions: a specular highlight that tracks the cursor
+// across glass surfaces, plus a press ripple on the action buttons. This is pure
+// flourish, so it only runs for fine pointers (mouse/trackpad) when the user
+// hasn't asked to reduce motion — touch devices and reduced-motion users keep the
+// CSS defaults, where --pointer stays 0 and no sheen or ripple ever appears.
+
+const SHEEN_SELECTOR = "[data-glass]";
+const RIPPLE_SELECTOR = ".button, .icon-button";
+
+function setPointer(el: HTMLElement, x: number, y: number): void {
+  const rect = el.getBoundingClientRect();
+  el.style.setProperty("--mx", `${((x - rect.left) / rect.width) * 100}%`);
+  el.style.setProperty("--my", `${((y - rect.top) / rect.height) * 100}%`);
+  el.style.setProperty("--pointer", "1");
+}
+
+function clearPointer(el: HTMLElement): void {
+  el.style.setProperty("--pointer", "0");
+}
+
+function spawnRipple(el: HTMLElement, x: number, y: number): void {
+  const rect = el.getBoundingClientRect();
+  const ripple = document.createElement("span");
+  ripple.className = "glass-ripple";
+  ripple.style.setProperty("--rx", `${x - rect.left}px`);
+  ripple.style.setProperty("--ry", `${y - rect.top}px`);
+  ripple.addEventListener("animationend", () => ripple.remove(), { once: true });
+  el.appendChild(ripple);
+}
+
+export function setupGlass(): void {
+  const finePointer = window.matchMedia("(pointer: fine)").matches;
+  const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  if (!finePointer || reduceMotion) return;
+
+  let active: HTMLElement | null = null;
+
+  // One delegated listener drives the sheen on whichever glass surface the
+  // pointer is currently over, including toasts that mount after load.
+  document.addEventListener(
+    "pointermove",
+    (e) => {
+      const surface = (e.target as Element | null)?.closest<HTMLElement>(SHEEN_SELECTOR) ?? null;
+      if (surface !== active) {
+        if (active) clearPointer(active);
+        active = surface;
+      }
+      if (surface) setPointer(surface, e.clientX, e.clientY);
+    },
+    { passive: true },
+  );
+
+  // Reset the highlight when the pointer leaves the window entirely.
+  document.addEventListener("pointerleave", () => {
+    if (active) {
+      clearPointer(active);
+      active = null;
+    }
+  });
+
+  document.addEventListener(
+    "pointerdown",
+    (e) => {
+      if (e.button !== 0) return;
+      const target = (e.target as Element | null)?.closest<HTMLElement>(RIPPLE_SELECTOR);
+      if (!target || (target as HTMLButtonElement).disabled) return;
+      haptic(5);
+      spawnRipple(target, e.clientX, e.clientY);
+    },
+    { passive: true },
+  );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { currentMode, parsers, type Mode } from "./parsers";
 import { EXAMPLE_JSON, EXAMPLE_JSON5 } from "./examples";
 import { haptic, requireEl, toast } from "./toast";
 import { currentTheme, onThemeChange, setupTheme } from "./theme";
+import { setupGlass } from "./glass";
 
 const INDENT = 2;
 
@@ -74,10 +75,24 @@ function minify(): void {
   if (result.ok) editor.setValue(result.codec.stringify(result.value, undefined));
 }
 
+// Replay the one-shot sheen-sweep across the editor: drop the class, force a
+// reflow so the animation can restart, then re-add it and clear up on finish.
+function flashSweep(): void {
+  dropZone.classList.remove("is-validated");
+  void dropZone.offsetWidth;
+  dropZone.classList.add("is-validated");
+  dropZone.addEventListener(
+    "animationend",
+    () => dropZone.classList.remove("is-validated"),
+    { once: true },
+  );
+}
+
 function validate(): void {
   const parser = activeParser();
   const result = parse();
   if (result.ok) {
+    flashSweep();
     toast(`Your input is valid ${parser.label}.`, {
       type: "success",
       title: `Valid ${parser.label}`,
@@ -211,6 +226,7 @@ setupTheme(themeToggle);
 onThemeChange((theme) => editor.setTheme(theme));
 refreshButtons();
 setupDropZone();
+setupGlass();
 
 for (const button of actionButtons) {
   button.addEventListener("click", () => {
@@ -222,9 +238,21 @@ for (const button of actionButtons) {
 
 // A light tick when switching format mode, matching the sliding-pill motion, and
 // keep the editor's linter in sync with the selected mode.
+const modeToggle = document.querySelector<HTMLElement>(".mode-toggle");
 for (const radio of document.querySelectorAll<HTMLInputElement>('input[name="mode"]')) {
   radio.addEventListener("change", () => {
     haptic(6);
     editor.setMode(currentMode());
+    // Drive the thumb's liquid stretch for the length of the slide.
+    if (modeToggle) {
+      modeToggle.classList.remove("is-sliding");
+      void modeToggle.offsetWidth;
+      modeToggle.classList.add("is-sliding");
+      modeToggle.addEventListener(
+        "animationend",
+        () => modeToggle.classList.remove("is-sliding"),
+        { once: true },
+      );
+    }
   });
 }

--- a/src/style.css
+++ b/src/style.css
@@ -19,15 +19,44 @@
     --glass-bg-strong: rgba(255, 255, 255, 0.78);
     --glass-border: rgba(255, 255, 255, 0.7);
     --glass-highlight: rgba(255, 255, 255, 0.85);
-    --glass-blur: 18px;
+    --glass-blur: 20px;
+    /* Lensing: brighten + saturate + a touch of contrast so the backdrop
+       appears refracted through the glass rather than just blurred. */
+    --glass-filter: blur(var(--glass-blur)) saturate(180%) brightness(1.06) contrast(1.02);
     --glass-shadow: 0 8px 24px rgba(18, 26, 41, 0.12), 0 2px 6px rgba(18, 26, 41, 0.06);
+    /* Deeper, layered shadow for the hero editor surface. */
+    --glass-shadow-lg:
+        0 1px 1px rgba(255, 255, 255, 0.5) inset,
+        0 18px 50px -12px rgba(18, 26, 41, 0.28),
+        0 8px 20px -8px rgba(18, 26, 41, 0.18);
     --accent-glass: rgba(47, 111, 237, 0.82);
     --accent-glass-strong: rgba(47, 111, 237, 0.95);
 
+    /* Specular rim — a light source catching the top-left edge of the lens,
+       fading to a soft shadow at the bottom-right. Used as a gradient border. */
+    --glass-rim: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.95) 0%,
+        rgba(255, 255, 255, 0.35) 26%,
+        rgba(255, 255, 255, 0) 48%,
+        rgba(18, 26, 41, 0) 60%,
+        rgba(18, 26, 41, 0.12) 100%
+    );
+    --glass-sheen: rgba(255, 255, 255, 0.55);
+    --glass-inner-glow: rgba(255, 255, 255, 0.6);
+
+    /* Pointer-tracking position (updated per-surface by glass.ts). Safe
+       defaults keep the centred highlight static when JS is off. */
+    --mx: 50%;
+    --my: 50%;
+    --pointer: 0;
+
     /* Soft ambient backdrop blobs */
-    --blob-1: rgba(99, 152, 255, 0.35);
-    --blob-2: rgba(126, 110, 245, 0.28);
-    --blob-3: rgba(64, 196, 198, 0.26);
+    --blob-1: rgba(99, 152, 255, 0.42);
+    --blob-2: rgba(126, 110, 245, 0.34);
+    --blob-3: rgba(64, 196, 198, 0.32);
+    --blob-4: rgba(255, 122, 182, 0.24);
+    --blob-5: rgba(120, 220, 180, 0.22);
 
     --radius: 20px;
     --radius-sm: 14px;
@@ -62,12 +91,30 @@
     --glass-border: rgba(255, 255, 255, 0.12);
     --glass-highlight: rgba(255, 255, 255, 0.18);
     --glass-shadow: 0 12px 32px rgba(0, 0, 0, 0.5), 0 2px 8px rgba(0, 0, 0, 0.35);
+    --glass-shadow-lg:
+        0 1px 1px rgba(255, 255, 255, 0.12) inset,
+        0 20px 56px -12px rgba(0, 0, 0, 0.66),
+        0 8px 22px -8px rgba(0, 0, 0, 0.5);
     --accent-glass: rgba(91, 141, 239, 0.8);
     --accent-glass-strong: rgba(91, 141, 239, 0.92);
 
-    --blob-1: rgba(64, 104, 200, 0.4);
-    --blob-2: rgba(108, 84, 220, 0.34);
-    --blob-3: rgba(40, 150, 160, 0.3);
+    /* Dimmer rim + cooler sheen against the dark backdrop. */
+    --glass-rim: linear-gradient(
+        135deg,
+        rgba(255, 255, 255, 0.5) 0%,
+        rgba(255, 255, 255, 0.16) 26%,
+        rgba(255, 255, 255, 0) 48%,
+        rgba(0, 0, 0, 0) 60%,
+        rgba(0, 0, 0, 0.4) 100%
+    );
+    --glass-sheen: rgba(168, 198, 255, 0.4);
+    --glass-inner-glow: rgba(255, 255, 255, 0.16);
+
+    --blob-1: rgba(64, 104, 200, 0.46);
+    --blob-2: rgba(108, 84, 220, 0.4);
+    --blob-3: rgba(40, 150, 160, 0.34);
+    --blob-4: rgba(190, 70, 140, 0.3);
+    --blob-5: rgba(40, 160, 120, 0.26);
 }
 
 * {
@@ -108,28 +155,166 @@ body {
     touch-action: manipulation;
 }
 
-/* Soft ambient backdrop for the Liquid Glass surfaces to refract */
+/* Soft ambient backdrop for the Liquid Glass surfaces to refract. Two stacked
+   blob layers drift on independent timings so the mesh never visibly loops, and
+   a faint grain layer kills gradient banding and adds tactile depth. */
 .ambient {
     position: fixed;
     inset: 0;
     z-index: -1;
     overflow: hidden;
     pointer-events: none;
+    background: var(--bg);
+}
+
+.ambient::before,
+.ambient::after {
+    content: "";
+    position: absolute;
+    inset: -15%;
+    pointer-events: none;
+}
+
+/* Primary mesh — large slow blobs. */
+.ambient::before {
     background:
         radial-gradient(42rem 42rem at 12% 18%, var(--blob-1), transparent 60%),
         radial-gradient(38rem 38rem at 88% 22%, var(--blob-2), transparent 60%),
-        radial-gradient(46rem 46rem at 50% 96%, var(--blob-3), transparent 62%),
-        var(--bg);
-    animation: ambient-drift 32s ease-in-out infinite alternate;
+        radial-gradient(46rem 46rem at 50% 96%, var(--blob-3), transparent 62%);
+    animation: ambient-drift 34s ease-in-out infinite alternate;
+}
+
+/* Secondary mesh — smaller accent blobs drifting the other way for an organic,
+   non-repeating wash of colour. */
+.ambient::after {
+    background:
+        radial-gradient(30rem 30rem at 78% 72%, var(--blob-4), transparent 64%),
+        radial-gradient(34rem 34rem at 22% 80%, var(--blob-5), transparent 64%);
+    animation: ambient-drift-alt 47s ease-in-out infinite alternate;
+}
+
+/* Subtle film grain so the broad gradients don't band on wide displays. */
+.ambient-grain {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    opacity: 0.04;
+    mix-blend-mode: overlay;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+[data-theme="dark"] .ambient-grain {
+    opacity: 0.07;
+    mix-blend-mode: soft-light;
 }
 
 @keyframes ambient-drift {
     from {
-        transform: translate3d(-2%, -1%, 0) scale(1.05);
+        transform: translate3d(-2%, -1%, 0) scale(1.05) rotate(0deg);
     }
 
     to {
-        transform: translate3d(2%, 1.5%, 0) scale(1.12);
+        transform: translate3d(2%, 1.5%, 0) scale(1.12) rotate(2deg);
+    }
+}
+
+@keyframes ambient-drift-alt {
+    from {
+        transform: translate3d(2%, 2%, 0) scale(1.1) rotate(0deg);
+    }
+
+    to {
+        transform: translate3d(-3%, -1.5%, 0) scale(1.04) rotate(-3deg);
+    }
+}
+
+/* ----------------------------------------------------- Liquid Glass surfaces */
+
+/* A reusable specular rim: a gradient "border" that catches light at the
+   top-left and falls into shadow at the bottom-right, masked so only the 1px
+   edge paints. Applied to every glass surface via [data-glass]. */
+[data-glass] {
+    position: relative;
+    isolation: isolate;
+}
+
+[data-glass]::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: var(--glass-rim);
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    pointer-events: none;
+    z-index: 3;
+}
+
+/* A soft specular highlight that tracks the pointer (glass.ts writes --mx/--my
+   and flips --pointer to 1 on hover). It fades in only while a fine pointer is
+   over the surface, so it's invisible on touch and with JS disabled.
+
+   Explicit list rather than [data-glass]::before so it doesn't collide with the
+   mode-toggle's own ::before (the sliding thumb), which carries data-glass too. */
+.icon-button::before,
+.button::before,
+.toast::before,
+.editor::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(
+        circle at var(--mx) var(--my),
+        var(--glass-sheen),
+        transparent 42%
+    );
+    opacity: calc(var(--pointer) * 0.5);
+    transition: opacity 0.3s var(--ease-out-ios);
+    pointer-events: none;
+    z-index: 1;
+    mix-blend-mode: screen;
+}
+
+[data-theme="dark"] :is(.icon-button, .button, .toast, .editor)::before {
+    opacity: calc(var(--pointer) * 0.6);
+}
+
+/* On the editor the sheen must sit behind the code, so the layer drops below the
+   content (which is lifted to z-index 1 below) and uses a gentler ceiling. */
+.editor::before {
+    z-index: 0;
+    opacity: calc(var(--pointer) * 0.35);
+}
+
+/* Press ripple spawned at the pointer-down point for gel-like feedback. */
+.glass-ripple {
+    position: absolute;
+    top: var(--ry, 50%);
+    left: var(--rx, 50%);
+    width: 14px;
+    height: 14px;
+    margin: -7px 0 0 -7px;
+    border-radius: 50%;
+    background: radial-gradient(circle, var(--glass-sheen), transparent 70%);
+    pointer-events: none;
+    z-index: 2;
+    opacity: 0.55;
+    animation: glass-ripple 0.6s var(--ease-out-ios) forwards;
+}
+
+@keyframes glass-ripple {
+    from {
+        transform: scale(0.3);
+        opacity: 0.55;
+    }
+    to {
+        transform: scale(14);
+        opacity: 0;
     }
 }
 
@@ -176,11 +361,13 @@ body {
     border-radius: 50%;
     border: 1px solid var(--glass-border);
     background: var(--glass-bg);
-    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
-    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    -webkit-backdrop-filter: var(--glass-filter);
+    backdrop-filter: var(--glass-filter);
     box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
     color: var(--text);
     cursor: pointer;
+    /* Contain the press ripple within the round button. */
+    overflow: hidden;
     transition: background 0.15s ease, transform 0.3s var(--ease-spring), border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
@@ -190,7 +377,11 @@ body {
 
 .icon-button:active {
     transform: scale(0.88);
-    transition-duration: 0.06s;
+    box-shadow:
+        var(--glass-shadow),
+        inset 0 2px 6px rgba(18, 26, 41, 0.22),
+        inset 0 1px 0 var(--glass-highlight);
+    transition-duration: 0.08s;
 }
 
 .theme-icon {
@@ -235,13 +426,14 @@ body {
     border: 1px solid var(--glass-border);
     border-radius: var(--radius-pill);
     background: var(--glass-bg);
-    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
-    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    -webkit-backdrop-filter: var(--glass-filter);
+    backdrop-filter: var(--glass-filter);
     box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
 }
 
 /* Sliding thumb — the single highlight that glides between the two options,
-   like an iOS segmented control. */
+   like an iOS segmented control. Position is driven by the `translate` property
+   so the `scale` property is free for an independent liquid stretch mid-slide. */
 .mode-toggle::before {
     content: "";
     position: absolute;
@@ -252,12 +444,25 @@ body {
     border-radius: var(--radius-pill);
     background: var(--glass-bg-strong);
     box-shadow: 0 2px 8px rgba(18, 26, 41, 0.16), inset 0 1px 0 var(--glass-highlight);
-    transition: transform 0.34s var(--ease-ios);
+    translate: 0 0;
+    transition: translate 0.34s var(--ease-ios);
     pointer-events: none;
+    z-index: 0;
 }
 
 .mode-toggle:has(.mode-option:last-child input:checked)::before {
-    transform: translateX(100%);
+    translate: 100% 0;
+}
+
+/* main.ts adds .is-sliding for the slide duration; the thumb squashes wider and
+   shorter at the midpoint then settles, so it "flows" rather than rigidly slides. */
+.mode-toggle.is-sliding::before {
+    animation: thumb-stretch 0.34s var(--ease-ios);
+}
+
+@keyframes thumb-stretch {
+    0%, 100% { scale: 1 1; }
+    45% { scale: 1.16 0.84; }
 }
 
 .mode-option {
@@ -306,8 +511,8 @@ body {
     appearance: none;
     border: 1px solid var(--accent-glass-strong);
     background: var(--accent-glass);
-    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
-    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    -webkit-backdrop-filter: var(--glass-filter);
+    backdrop-filter: var(--glass-filter);
     box-shadow: var(--glass-shadow), inset 0 1px 0 rgba(255, 255, 255, 0.4);
     color: var(--accent-contrast);
     font: inherit;
@@ -316,6 +521,8 @@ body {
     padding: 0.5rem 1.1rem;
     border-radius: var(--radius-pill);
     cursor: pointer;
+    /* Contain the press ripple within the pill. */
+    overflow: hidden;
     transition: filter 0.15s ease, transform 0.22s var(--ease-spring), background 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
 }
 
@@ -325,8 +532,14 @@ body {
 }
 
 .button:active:not(:disabled) {
-    transform: scale(0.95);
-    transition-duration: 0.06s;
+    /* Gel squish: shrink, sink a hair, and deepen the inner shadow so the
+       surface feels pressed in before springing back on release. */
+    transform: scale(0.95) translateY(1px);
+    box-shadow:
+        var(--glass-shadow),
+        inset 0 2px 6px rgba(18, 26, 41, 0.28),
+        inset 0 1px 0 rgba(255, 255, 255, 0.4);
+    transition-duration: 0.08s;
 }
 
 .button:focus-visible {
@@ -351,7 +564,8 @@ body {
     filter: none;
 }
 
-/* Editor */
+/* Editor — the hero glass surface, so it carries the deepest, most layered
+   shadow and a focus glow when the embedded editor is active. */
 .editor {
     position: relative;
     flex: 1;
@@ -359,20 +573,81 @@ body {
     border: 1px solid var(--glass-border);
     border-radius: var(--radius);
     background: var(--glass-bg);
-    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
-    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
-    box-shadow: var(--glass-shadow), inset 0 1px 0 var(--glass-highlight);
+    -webkit-backdrop-filter: var(--glass-filter);
+    backdrop-filter: var(--glass-filter);
+    box-shadow: var(--glass-shadow-lg);
     overflow: hidden;
-    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    transition: border-color 0.2s var(--ease-out-ios), box-shadow 0.3s var(--ease-out-ios);
+}
+
+/* When CodeMirror takes focus, lift the rim and wrap the lens in a soft accent
+   glow — the panel itself conveys focus (CodeMirror's own outline is dropped). */
+.editor:has(.cm-editor.cm-focused) {
+    border-color: var(--accent-glass);
+    box-shadow: var(--glass-shadow-lg), 0 0 0 1px var(--accent-glass), 0 0 28px -4px var(--accent-soft);
 }
 
 .editor.is-dragover {
     border-color: var(--accent);
-    box-shadow: var(--glass-shadow), 0 0 0 3px var(--accent-soft);
+    box-shadow: var(--glass-shadow-lg), 0 0 0 3px var(--accent-soft);
 }
 
-/* The editor host wraps a CodeMirror 6 instance which fills the glass panel. */
+/* Progressive enhancement: where a browser can run an SVG filter inside
+   backdrop-filter, add a gentle turbulence displacement so the ambient behind
+   the lens appears refracted. Guarded so the base blur is never dropped on
+   browsers that don't support url() backdrops. Only affects the backdrop — the
+   code on top stays perfectly crisp. */
+@supports (backdrop-filter: url("#liquid-glass")) or (-webkit-backdrop-filter: url("#liquid-glass")) {
+    .editor {
+        -webkit-backdrop-filter: var(--glass-filter) url("#liquid-glass");
+        backdrop-filter: var(--glass-filter) url("#liquid-glass");
+    }
+}
+
+/* A specular highlight that sweeps diagonally across the lens on a successful
+   validate — a quick "ping" of light. Sits above the code but ignores input. */
+.editor-sweep {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 2;
+    opacity: 0;
+    background: linear-gradient(
+        115deg,
+        transparent 30%,
+        var(--glass-sheen) 48%,
+        rgba(255, 255, 255, 0.1) 52%,
+        transparent 70%
+    );
+    background-size: 280% 100%;
+    background-position: 120% 0;
+    mix-blend-mode: screen;
+}
+
+.editor.is-validated .editor-sweep {
+    animation: editor-sweep 0.85s var(--ease-out-ios);
+}
+
+@keyframes editor-sweep {
+    0% {
+        opacity: 0;
+        background-position: 120% 0;
+    }
+    15% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+        background-position: -60% 0;
+    }
+}
+
+/* The editor host wraps a CodeMirror 6 instance which fills the glass panel.
+   Lifted above the pointer-sheen layer so code stays crisp. */
 .editor-input {
+    position: relative;
+    z-index: 1;
     flex: 1;
     display: flex;
     min-width: 0;
@@ -414,6 +689,8 @@ body {
 .drop-overlay {
     position: absolute;
     inset: 0;
+    /* Above the code, sweep and rim so it covers everything while dragging. */
+    z-index: 4;
     display: grid;
     place-items: center;
     background: var(--accent-soft);
@@ -454,8 +731,8 @@ body {
     padding: 0.7rem 1rem;
     border-radius: var(--radius-sm);
     background: var(--glass-bg-strong);
-    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(180%);
-    backdrop-filter: blur(var(--glass-blur)) saturate(180%);
+    -webkit-backdrop-filter: var(--glass-filter);
+    backdrop-filter: var(--glass-filter);
     color: var(--text);
     border: 1px solid var(--glass-border);
     border-left: 4px solid var(--accent);
@@ -534,7 +811,10 @@ body {
         transition-duration: 0.001ms !important;
     }
 
-    .ambient {
+    /* The universal selector above doesn't reach pseudo-elements, so silence the
+       drifting ambient layers explicitly. */
+    .ambient::before,
+    .ambient::after {
         animation: none;
     }
 }

--- a/src/toast.ts
+++ b/src/toast.ts
@@ -66,6 +66,8 @@ export function toast(
 ): void {
   const el = document.createElement("div");
   el.className = `toast toast--${type}`;
+  // Opt into the Liquid Glass surface treatment (specular rim + pointer sheen).
+  el.dataset.glass = "";
   if (title) {
     const heading = document.createElement("p");
     heading.className = "toast__title";


### PR DESCRIPTION
Push the existing glassmorphism toward Apple's Liquid Glass language:

- Specular rim lighting on every glass surface via a masked gradient-border
  ::after, plus a lensed backdrop-filter (brightness/contrast/saturate).
- Pointer-reactive specular sheen that tracks the cursor across glass
  surfaces, and a press ripple on the action buttons (new src/glass.ts,
  gated to fine pointers with reduced motion respected).
- Richer living backdrop: two independently drifting blob meshes plus a
  subtle film-grain overlay to kill banding.
- Organic micro-interactions: gel-squish button presses, a liquid stretch
  on the mode-toggle thumb, an editor focus glow, and a sheen sweep on a
  successful validate.
- Optional SVG turbulence/displacement refraction on the editor backdrop,
  guarded by @supports so the base blur is never dropped.

All new motion stays behind prefers-reduced-motion and the existing
no-backdrop-filter fallback, so touch and unsupported browsers degrade
gracefully.